### PR TITLE
Fixed escaping of path

### DIFF
--- a/lib/concatenate.js
+++ b/lib/concatenate.js
@@ -18,12 +18,15 @@ var Module = {
   concatenate: function(directory,ignore,modulePath){
     var self= this;
     var data = {};
+    var re = /\\/g;
+    var subst = '\\\\';
     recursive(directory,ignore,function (err, files){
       if(err){
         self.buildError(err);
       }
       var c=0;
       files.forEach(function(file){
+        file = file.replace(re, subst);
         c++;
         fs.readFile(file,'utf-8',function(err,html){
           if (err) throw err;


### PR DESCRIPTION
Related to this [issue](https://github.com/ngCli/ng-cli/issues/6). I've tested my addition in Windows 8.1 and it is working now.
The problem was that the generated js object in snippet.js was not valid because the \ was not properly escaped. Before my code the snippet had the following keys 'content\controller\controller.coffee' and that's not valid for json and now it is like - 'content\\controller\\controller.coffee' with escaped back-slashes. The error message mentioned in the issue disapeared.

To the code:
I'm not sure why the escaping from `files` array is removed in the foreach-loop where I've re-added the escaping but I think that's the easiest way to fix the problem. If you `console.log(files)` you'll see that the items are correctly esacped with double back-slashes.
